### PR TITLE
Add chat export to markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,10 +90,15 @@
         "title": "Open Workspace in New Window",
         "icon": "$(link-external)"
       },
-      {
+      { 
         "command": "copilotChatHistory.openChatJson",
         "title": "Open JSON File",
         "icon": "$(file-code)"
+      },
+      {
+        "command": "copilotChatHistory.exportChatMarkdown",
+        "title": "Export Chat as Markdown",
+        "icon": "$(export)"
       }
     ],
     "menus": {
@@ -124,6 +129,11 @@
           "command": "copilotChatHistory.openChatJson",
           "when": "view == copilotChatHistoryView && viewItem == chatSession",
           "group": "chat@2"
+        },
+        {
+          "command": "copilotChatHistory.exportChatMarkdown",
+          "when": "view == copilotChatHistoryView && viewItem == chatSession",
+          "group": "chat@3"
         },
         {
           "command": "copilotChatHistory.openWorkspaceInCurrentWindow",

--- a/src/markdown/chatMarkdown.ts
+++ b/src/markdown/chatMarkdown.ts
@@ -1,0 +1,125 @@
+import type { ChatMessage, ChatSession, ChatSessionData } from '../types';
+
+export function buildChatMarkdown(sessionData: ChatSessionData, session: ChatSession): string {
+    const sections: string[] = [];
+    sections.push(renderChatMetadata(sessionData, session));
+
+    const messagesSection = renderChatMessages(sessionData);
+    if (messagesSection) {
+        sections.push(messagesSection);
+    }
+
+    return sections.join('\n\n');
+}
+
+export function sanitizeFileName(name: string): string {
+    const sanitized = name.replace(/[\\/:*?"<>|]/g, '_').trim() || 'chat-session';
+    const MAX_FILENAME_LENGTH = 255;
+    return sanitized.length > MAX_FILENAME_LENGTH ? sanitized.substring(0, MAX_FILENAME_LENGTH) : sanitized;
+}
+
+function renderChatMetadata(sessionData: ChatSessionData, session: ChatSession): string {
+    const title = escapeMarkdownInline(session.customTitle || `Chat Session ${session.id}`);
+    const workspaceName = session.workspaceName || 'Unknown workspace';
+    const workspaceLine = session.workspacePath
+        ? `${workspaceName} (${session.workspacePath})`
+        : workspaceName;
+    const messageCount = session.messageCount ?? (sessionData.requests?.length ?? 0);
+    const metadataLines: string[] = [
+        `# ${title}`,
+        '',
+        `- **Workspace:** ${escapeMarkdownInline(workspaceLine)}`,
+        `- **Messages:** ${messageCount.toString()}`
+    ];
+
+    const createdDate = formatDate(sessionData.creationDate);
+    if (createdDate) {
+        metadataLines.push(`- **Created:** ${escapeMarkdownInline(createdDate)}`);
+    }
+
+    const lastActivity = sessionData.lastMessageDate ?? session.lastModified.getTime();
+    const lastActivityLabel = sessionData.lastMessageDate ? 'Last message' : 'Last modified';
+    metadataLines.push(`- **${lastActivityLabel}:** ${escapeMarkdownInline(formatDate(lastActivity))}`);
+
+    return metadataLines.join('\n');
+}
+
+function renderChatMessages(sessionData: ChatSessionData): string | undefined {
+    const messages = sessionData.requests || [];
+    if (messages.length === 0) {
+        return '_No messages in this chat session._';
+    }
+
+    const requester = sessionData.requesterUsername || 'User';
+    const responder = sessionData.responderUsername || 'GitHub Copilot';
+
+    const blocks = messages
+        .map((request, index) => renderChatMessageBlock(request, index, requester, responder))
+        .filter((block): block is string => Boolean(block && block.trim()));
+
+    return blocks.join('\n\n');
+}
+
+function renderChatMessageBlock(
+    request: ChatMessage,
+    index: number,
+    requester: string,
+    responder: string
+): string | undefined {
+    const lines: string[] = [];
+    const messageNumber = index + 1;
+
+    const userText = request.message?.text?.trim();
+    if (userText) {
+        lines.push(`## Message ${messageNumber} — ${escapeMarkdownInline(requester)}`);
+        if (request.timestamp) {
+            const formattedTimestamp = formatDate(request.timestamp);
+            if (formattedTimestamp) {
+                lines.push(`*${escapeMarkdownInline(formattedTimestamp)}*`);
+            }
+        }
+        lines.push('');
+        lines.push(escapeMarkdownMultiline(userText));
+    }
+
+    const responseText = request.response
+        ?.map(response => response.value)
+        .filter((value): value is string => Boolean(value && value.trim()))
+        .join('\n\n');
+
+    if (responseText) {
+        if (lines.length > 0) {
+            lines.push('');
+        }
+        lines.push(`### Response ${messageNumber} — ${escapeMarkdownInline(responder)}`);
+        lines.push('');
+        lines.push(escapeMarkdownMultiline(responseText.trim()));
+    }
+
+    return lines.length > 0 ? lines.join('\n') : undefined;
+}
+
+function escapeMarkdownInline(text: string): string {
+    return text.replace(/([\\`*_{}\[\]()#+\-!.>|])/g, '\\$1');
+}
+
+function escapeMarkdownMultiline(text: string): string {
+    return text
+        .split('\n')
+        .map(line => {
+            if (line.trim().startsWith('```')) {
+                return line.replace(/`/g, '\\`');
+            }
+            return escapeMarkdownInline(line);
+        })
+        .join('\n');
+}
+
+function formatDate(value: number | Date | undefined): string {
+    if (value === undefined) {
+        return '';
+    }
+
+    const date = value instanceof Date ? value : new Date(value);
+    return date.toISOString();
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,30 @@
+export interface ChatSession {
+    id: string;
+    customTitle?: string;
+    workspaceName: string;
+    workspacePath?: string;
+    lastModified: Date;
+    filePath: string;
+    messageCount: number;
+    storageRoot: string;
+}
+
+export interface ChatMessage {
+    message?: {
+        text?: string;
+    };
+    response?: Array<{
+        value?: string;
+    }>;
+    timestamp?: number;
+}
+
+export interface ChatSessionData {
+    version: number;
+    requesterUsername: string;
+    responderUsername: string;
+    requests: ChatMessage[];
+    customTitle?: string;
+    creationDate?: number;
+    lastMessageDate?: number;
+}

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -1,0 +1,32 @@
+import * as vscode from 'vscode';
+
+const shownErrorContexts = new Map<string, ReturnType<typeof setTimeout>>();
+
+export function showCentralizedError(message: string, context: string, resetDelayMs: number = 5000): void {
+    if (shownErrorContexts.has(context)) {
+        return;
+    }
+
+    vscode.window.showErrorMessage(message);
+
+    const timeoutHandle = setTimeout(() => {
+        shownErrorContexts.delete(context);
+    }, resetDelayMs);
+
+    shownErrorContexts.set(context, timeoutHandle);
+}
+
+export function clearErrorContext(context: string): void {
+    const timeoutHandle = shownErrorContexts.get(context);
+    if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+        shownErrorContexts.delete(context);
+    }
+}
+
+export function clearAllErrorContexts(): void {
+    for (const [context, timeoutHandle] of shownErrorContexts.entries()) {
+        clearTimeout(timeoutHandle);
+        shownErrorContexts.delete(context);
+    }
+}

--- a/src/utils/sessionFiles.ts
+++ b/src/utils/sessionFiles.ts
@@ -1,0 +1,93 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import type { ChatSession, ChatSessionData } from '../types';
+
+export class SessionFileError extends Error {
+    readonly context: string;
+    readonly cause?: unknown;
+
+    constructor(message: string, context: string, options?: { cause?: unknown }) {
+        super(message);
+        this.name = 'SessionFileError';
+        this.context = context;
+        if (options?.cause !== undefined) {
+            this.cause = options.cause;
+        }
+    }
+}
+
+export async function resolveSessionFilePath(session: ChatSession): Promise<string> {
+    if (!session.filePath || !session.storageRoot) {
+        throw new SessionFileError('Session is missing file path metadata.', 'sessionPath:metadataMissing');
+    }
+
+    try {
+        const [realFilePath, realRoot] = await Promise.all([
+            fs.promises.realpath(session.filePath),
+            fs.promises.realpath(session.storageRoot)
+        ]);
+
+        const relative = path.relative(realRoot, realFilePath);
+        if (relative.startsWith('..') || path.isAbsolute(relative)) {
+            throw new SessionFileError(
+                `Session file path is outside of expected directory: ${session.filePath}`,
+                'sessionPath:outsideRoot'
+            );
+        }
+
+        return realFilePath;
+    } catch (error) {
+        if (error instanceof SessionFileError) {
+            throw error;
+        }
+        throw new SessionFileError(
+            'Error resolving real paths for session file or storage root.',
+            'sessionPath:resolutionFailed',
+            { cause: error }
+        );
+    }
+}
+
+export async function resolveAccessibleSessionFilePath(
+    session: ChatSession,
+    accessMode: number = fs.constants.R_OK
+): Promise<string> {
+    const sessionFilePath = await resolveSessionFilePath(session);
+
+    try {
+        await fs.promises.access(sessionFilePath, accessMode);
+        return sessionFilePath;
+    } catch (error) {
+        throw new SessionFileError(
+            `Chat session file not found: ${sessionFilePath}`,
+            'sessionPath:notFound',
+            { cause: error }
+        );
+    }
+}
+
+export async function loadSessionData(session: ChatSession): Promise<{ filePath: string; data: ChatSessionData }> {
+    const sessionFilePath = await resolveAccessibleSessionFilePath(session);
+
+    let sessionRaw: string;
+    try {
+        sessionRaw = await fs.promises.readFile(sessionFilePath, 'utf8');
+    } catch (error) {
+        throw new SessionFileError(
+            `Unable to read chat session file: ${sessionFilePath}`,
+            'sessionFile:readFailed',
+            { cause: error }
+        );
+    }
+
+    try {
+        const sessionData = JSON.parse(sessionRaw) as ChatSessionData;
+        return { filePath: sessionFilePath, data: sessionData };
+    } catch (error) {
+        throw new SessionFileError(
+            `Chat session file is invalid or corrupted: ${sessionFilePath}`,
+            'sessionFile:parseFailed',
+            { cause: error }
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add command and menu entry to export chat sessions as markdown files
- generate markdown files with session metadata and message content, and prompt for save location

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf25213a648320bd3a7844abc75033

## Summary by Sourcery

Add an “Export Chat as Markdown” feature with UI integration and underlying utilities for safe session loading and markdown generation

New Features:
- Register a new command and context menu entry to export chat sessions as markdown files
- Prompt for a save location and handle file overwrite confirmation when exporting

Enhancements:
- Introduce session file resolution and access functions to securely locate and read session data
- Refactor chat opening commands to asynchronously load session data and display errors
- Implement markdown builder utilities for formatting session metadata and messages with proper escaping and filename sanitization